### PR TITLE
Fixed bug

### DIFF
--- a/ffmpeg_streaming/clouds.py
+++ b/ffmpeg_streaming/clouds.py
@@ -205,7 +205,7 @@ def open_from_cloud(cloud):
 
 def save_to_clouds(clouds, dirname):
     if clouds is not None:
-        if type(clouds) != list or type(clouds) != tuple:
+        if not isinstance(clouds, (list, tuple)):
             raise TypeError('Clouds must be type of list or tuple')
 
         if type(clouds) == tuple:


### PR DESCRIPTION
Because of short circuiting if `clouds` was a `tuple` this line would have failed since it wasn't a `list`. Also it shouldn't be checking types via `==`.

| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Fixed type checking bug.