### PR TITLE
don't fail when no audio tracks

### DIFF
--- a/ffmpeg_streaming/_media_streams.py
+++ b/ffmpeg_streaming/_media_streams.py
@@ -26,7 +26,12 @@ class Streams:
         """
         @TODO: add documentation
         """
-        return self._get_stream('audio')
+        try:
+            audio = self._get_stream('audio')
+        # no audio tracks
+        except ValueError:
+            audio = {}
+        return audio
 
     def first_stream(self):
         """

--- a/ffmpeg_streaming/_media_streams.py
+++ b/ffmpeg_streaming/_media_streams.py
@@ -16,22 +16,17 @@ class Streams:
     def __init__(self, streams):
         self.streams = streams
 
-    def video(self):
+    def video(self, ignore_error=True):
         """
         @TODO: add documentation
         """
-        return self._get_stream('video')
-
-    def audio(self):
+        return self._get_stream('video', ignore_error)    
+        
+    def audio(self, ignore_error=True):
         """
         @TODO: add documentation
         """
-        try:
-            audio = self._get_stream('audio')
-        # no audio tracks
-        except ValueError:
-            audio = {}
-        return audio
+        return self._get_stream('audio', ignore_error)
 
     def first_stream(self):
         """
@@ -57,14 +52,14 @@ class Streams:
         """
         return self._get_streams('audio')
 
-    def _get_stream(self, media):
+    def _get_stream(self, media, ignore_error):
         """
         @TODO: add documentation
         """
         media_attr = next((stream for stream in self.streams if stream['codec_type'] == media), None)
-        if media_attr is None:
+        if media_attr is None and not ignore_error:
             raise ValueError('No ' + str(media) + ' stream found')
-        return media_attr
+        return media_attr if media_attr is not None else {}
 
     def _get_streams(self, media):
         """


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?


#### Why?

```
    hls.auto_generate_representations()
  File "/envs/stream3.6/lib/python3.6/site-packages/ffmpeg_streaming/_media.py", line 113, in auto_generate_representations
    self.reps = AutoRep(self.probe.video_size, self.probe.bitrate, self.format, heights, bitrate)
  File "/envs/stream3.6/lib/python3.6/site-packages/ffmpeg_streaming/ffprobe.py", line 81, in bitrate
    audio = int(self.streams().audio().get('bit_rate', 0))
  File "/envs/stream3.6/lib/python3.6/site-packages/ffmpeg_streaming/_media_streams.py", line 29, in audio
    return self._get_stream('audio')
  File "/envs/stream3.6/lib/python3.6/site-packages/ffmpeg_streaming/_media_streams.py", line 61, in _get_stream
    raise ValueError('No ' + str(media) + ' stream found')
ValueError: No audio stream found

```
#### To Do

- [ ] Create tests