### PR TITLE
Fix RecursionError in Media ctor #54 #49

### DIFF
--- a/ffmpeg_streaming/_media.py
+++ b/ffmpeg_streaming/_media.py
@@ -243,7 +243,7 @@ class Media(object):
         """
         self.inputs = _inputs
 
-        first_input = dict(copy.deepcopy(_inputs.inputs[0]))
+        first_input = dict(copy.copy(_inputs.inputs[0]))
         self.input = first_input.get('i', None)
         self.input_temp = first_input.get('is_tmp', False)
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #54 #49
| Related issues/PRs | #54 #49
| License            | MIT

#### What's in this PR?

A fix in Media constructor method avoiding infinite recursion.

#### Why?

Infinite recursion triggered by deepcopy. A simple copy instead fixes the case.
