### PR TITLE
Fixed Typo in _format.py of line 66 from h264_afm to h264_amf

### DIFF
--- a/ffmpeg_streaming/_format.py
+++ b/ffmpeg_streaming/_format.py
@@ -63,7 +63,7 @@ class H264(Format):
         """
         @TODO: add documentation
         """
-        videos = ['libx264', 'h264', 'h264_afm', 'h264_nvenc']
+        videos = ['libx264', 'h264', 'h264_amf', 'h264_nvenc']
         audios = ['copy', 'aac', 'libvo_aacenc', 'libfaac', 'libmp3lame', 'libfdk_aac']
 
         super(H264, self).__init__(_verify_codecs(video, videos), _verify_codecs(audio, audios), **codec_options)


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #98 
| Related issues/PRs | none
| License            | MIT

#### What's in this PR?

Changes a Small Typo on line 66 in _format.py from h264.afm to h264.amf

#### Why?
Changes a Typo 
