### PR TITLE
Added adaptation_sets parameter for ffmpeg

### DIFF
--- a/ffmpeg_streaming/_command_builder.py
+++ b/ffmpeg_streaming/_command_builder.py
@@ -54,7 +54,6 @@ def _get_dash_stream(key, rep):
         'map': 0,
         f's:v:{str(key)}': rep.size,
         f'b:v:{str(key)}': rep.bitrate.calc_video(),
-        'adaptation_sets': 'id=0,streams=v id=1,streams=a',
     }
 
     args.update(_get_audio_bitrate(rep, key))
@@ -69,11 +68,12 @@ def _dash(dash):
     dirname, name = get_path_info(dash.output_)
     _args = dash.format.all
     _args.update({
-        'use_timeline':     USE_TIMELINE,
-        'use_template':     USE_TEMPLATE,
-        'init_seg_name':    '{}_init_$RepresentationID$.$ext$'.format(name),
-        "media_seg_name":   '{}_chunk_$RepresentationID$_$Number%05d$.$ext$'.format(name),
-        'f': 'dash'
+        'use_timeline': USE_TIMELINE,
+        'use_template': USE_TEMPLATE,
+        'init_seg_name': '{}_init_$RepresentationID$.$ext$'.format(name),
+        "media_seg_name": '{}_chunk_$RepresentationID$_$Number%05d$.$ext$'.format(name),
+        'f': 'dash',
+        'adaptation_sets': 'id=0,streams=v id=1,streams=a',
     })
     _args.update(dash.options)
     args = cnv_options_to_args(_args)

--- a/ffmpeg_streaming/_command_builder.py
+++ b/ffmpeg_streaming/_command_builder.py
@@ -54,6 +54,7 @@ def _get_dash_stream(key, rep):
         'map': 0,
         f's:v:{str(key)}': rep.size,
         f'b:v:{str(key)}': rep.bitrate.calc_video(),
+        'adaptation_sets': 'id=0,streams=v id=1,streams=a',
     }
 
     args.update(_get_audio_bitrate(rep, key))


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes?
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | ??
| Related issues/PRs | ??
| License            | MIT

#### What's in this PR?

I added the ffmpeg parameter `adaptation_sets` for dash streams

#### Why?

When testing DASH `mpd` generated by this project, the different qualities (representations) were not properly recognized in the dash.js reference player: http://reference.dashif.org/dash.js/nightly/samples/dash-if-reference-player/index.html

I tested with other players and none of them recognized the different representations *until* I added the `adaptation_sets` parameter.

#### BC Breaks/Deprecations

Probably breaks support for subtitles? I am not sure if it is even supported by the project.