### PR TITLE
kill ffmpeg process on finish up if enabled

### DIFF
--- a/ffmpeg_streaming/_media.py
+++ b/ffmpeg_streaming/_media.py
@@ -39,11 +39,11 @@ class Save(abc.ABC):
         self.key = None
         self.media = media
         self.format = _format
-        self.options = options
         self.pipe = None
         self.output_temp = False
         self.process = None
         self.kill_process_on_exit = options.pop('kill_process_on_exit', False)
+        self.options = options
 
     def finish_up(self):
         """

--- a/ffmpeg_streaming/_media.py
+++ b/ffmpeg_streaming/_media.py
@@ -42,6 +42,8 @@ class Save(abc.ABC):
         self.options = options
         self.pipe = None
         self.output_temp = False
+        self.process = None
+        self.kill_process_on_exit = options.pop('kill_process_on_exit', False)
 
     def finish_up(self):
         """
@@ -55,6 +57,8 @@ class Save(abc.ABC):
                 shutil.move(os.path.dirname(self.output_), os.path.dirname(str(self.output)))
             else:
                 shutil.rmtree(os.path.dirname(str(self.output_)), ignore_errors=True)
+        if self.kill_process_on_exit:
+            self.process.__exit__()
 
     @abc.abstractmethod
     def set_up(self):
@@ -103,6 +107,7 @@ class Save(abc.ABC):
         @TODO: add documentation
         """
         with Process(self, command_builder(ffmpeg_bin, self), monitor, **options) as process:
+            self.process = process
             self.pipe, err = process.run()
 
     async def async_run(self, ffmpeg_bin, monitor: callable = None, **options):
@@ -176,6 +181,7 @@ class HLS(Streaming):
     KEY_INFO_FILE_PATH = None
     PERIODIC_RE_KEY_FLAG = 'periodic_rekey'
     MASTER_PLAYLIST_IS_SAVED = False
+
 
     def set_up(self):
         """

--- a/ffmpeg_streaming/_media.py
+++ b/ffmpeg_streaming/_media.py
@@ -182,7 +182,6 @@ class HLS(Streaming):
     PERIODIC_RE_KEY_FLAG = 'periodic_rekey'
     MASTER_PLAYLIST_IS_SAVED = False
 
-
     def set_up(self):
         """
         @TODO: add documentation

--- a/ffmpeg_streaming/_process.py
+++ b/ffmpeg_streaming/_process.py
@@ -58,11 +58,14 @@ class Process(object):
         self.process = _p_open(commands, **options)
         self.media = media
         self.monitor = monitor
+        self.exited = False
 
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
+        logging.info("exiting ffmpeg process.")
+        self.exited = True
         self.process.kill()
 
     def _monitor(self):
@@ -119,8 +122,9 @@ class Process(object):
 
         if self.process.poll():
             error = str(Process.err) if Process.err else str(Process.out)
-            logging.error('ffmpeg failed to execute command: {}'.format(error))
-            raise RuntimeError('ffmpeg failed to execute command: ', error)
+            if not self.exited:
+                logging.error('ffmpeg failed to execute command: {}'.format(error))
+                raise RuntimeError('ffmpeg failed to execute command: ', error)
 
         logging.info("ffmpeg executed command successfully")
 


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Added an option to kill the ffmpeg process in the finish_up phase. Useful when using an input source as camera

#### Why?

Need to deallocate input source (camera) programatically once the stream is finished, so that it can be used again.

#### Example Usage

```python
video = ffmpeg_streaming.input("/dev/video0", capture=True)
hls = video.hls(Formats.h264(), kill_process_on_exit=True)

// Now we can do
hls.finish_up() // will stop the ffmpeg process and free the attached camera


#### To Do

- [ ] Create tests