### PR TITLE
add h264_videotoolbox codec

### DIFF
--- a/ffmpeg_streaming/_format.py
+++ b/ffmpeg_streaming/_format.py
@@ -63,7 +63,7 @@ class H264(Format):
         """
         @TODO: add documentation
         """
-        videos = ['libx264', 'h264', 'h264_amf', 'h264_nvenc']
+        videos = ['libx264', 'h264', 'h264_amf', 'h264_nvenc', 'h264_videotoolbox']
         audios = ['copy', 'aac', 'libvo_aacenc', 'libfaac', 'libmp3lame', 'libfdk_aac']
 
         super(H264, self).__init__(_verify_codecs(video, videos), _verify_codecs(audio, audios), **codec_options)


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | 
| Related issues/PRs | 
| License            | MIT

#### What's in this PR?

This PR introduces `h264_videotoolbox` as a new codec option specifically optimized for M1 Macs, aiming to enhance performance and efficiency.

#### Why?

The addition of the `h264_videotoolbox` codec is intended to exploit the hardware acceleration capabilities of M1 Macs, providing a significant performance boost. Initial tests have shown at least a 15% speedup in processing, making it a valuable enhancement for users on these devices.
