### PR TITLE
Allow multiple downloads

### DIFF
--- a/ffmpeg_streaming/_input.py
+++ b/ffmpeg_streaming/_input.py
@@ -14,8 +14,6 @@ from ffmpeg_streaming._media import Media
 from ffmpeg_streaming._utiles import get_os, cnv_options_to_args
 from ffmpeg_streaming._clouds import Clouds
 
-cloud = None
-
 
 class Capture(object):
     def __init__(self, video, options):
@@ -61,12 +59,8 @@ def get_from_cloud(_cloud: Clouds, options: dict):
     """
     @TODO: add documentation
     """
-    global cloud
-    if cloud is None:
-        save_to = options.pop('save_to', None)
-        cloud = {'i': _cloud.download(save_to, **options), 'is_tmp': save_to is None}
-
-    return cloud
+    save_to = options.pop('save_to', None)
+    return {'i': _cloud.download(save_to, **options), 'is_tmp': save_to is None}
 
 
 class InputOption(object):


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | 
| Related issues/PRs | 
| License            | MIT

#### What's in this PR?

Removed global cloud variable, and in get_from_cloud "_cloud.download" will always be called

#### Why?

When using the library to convert videos to stream, only the first time the file is downloaded from cloud. Next time because the global cloud variable exists, download won't happen, although file is changed
