### PR TITLE
Adding async_output when already running async the run call to asynci…

### DIFF
--- a/ffmpeg_streaming/_media.py
+++ b/ffmpeg_streaming/_media.py
@@ -126,7 +126,13 @@ class Save(abc.ABC):
         @TODO: add documentation
         """
         if async_run := options.pop('async_run', True):
-            asyncio.run(self.async_run(ffmpeg_bin, monitor, **options))
+            try:
+                # Raise a RuntimeError if no loop is running:
+                asyncio.get_running_loop()
+                return asyncio.create_task(self.async_run(ffmpeg_bin, monitor, **options))
+            except RuntimeError:
+                # No loop is running:
+                asyncio.run(self.async_run(ffmpeg_bin, monitor, **options))
         else:
             self._run(ffmpeg_bin, monitor, **options)
 

--- a/ffmpeg_streaming/_media.py
+++ b/ffmpeg_streaming/_media.py
@@ -69,6 +69,16 @@ class Save(abc.ABC):
 
         return method
 
+    async def async_output(self, output: str = None, clouds: CloudManager = None,
+               run_command: bool = True, ffmpeg_bin: str = 'ffmpeg', monitor: callable = None, **options):
+        """
+        @TODO: add documentation
+        """
+        self.output(output, clouds, run_command=False, ffmpeg_bin=ffmpeg_bin, monitor=monitor, **options)
+
+        if run_command:
+            await self.async_run(ffmpeg_bin="ffmpeg")
+
     def output(self, output: str = None, clouds: CloudManager = None,
                run_command: bool = True, ffmpeg_bin: str = 'ffmpeg', monitor: callable = None, **options):
         """


### PR DESCRIPTION
…o.run will raise an exception.

| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | yes
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #issuenum
| Related issues/PRs | #issuenum
| License            | MIT

#### What's in this PR?

Added a new function to _media.py called async_output

This new function internally calls the async_run instead of run. which can be awaited.

#### Why?

If already running within an asyncio event loop, the call under https://github.com/quasarstream/python-ffmpeg-video-streaming/blob/master/ffmpeg_streaming/_media.py#L119 will raise a RuntimeError:  "asyncio.run() cannot be called from a running event loop"

A workaround for the client is to avoid the `run_command` when running `stream.output` as seen below:

```python
    stream.output(output, run_command=False)
    await stream.async_run(ffmpeg_bin="ffmpeg")
```

Which problem does the PR fix?

#### Example Usage

```python
await stream.async_output(output)
~~~

#### To Do

- [ ] Create tests